### PR TITLE
CC reviewer on email once supervisor releases evaluation

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/util/Mailer.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/util/Mailer.java
@@ -130,6 +130,9 @@ public class Mailer implements MailerInterface {
         String mailCC = emailType.getCc();
         String mailBCC = emailType.getBcc();
 
+        // Modifying the CC recipient for the signature emails to include Classified. This was the simplest
+        // solution. Other things to consider in the future is: 1) use a different appraisal step + email type
+        // or 2) allow email_types to have an appointment type column
         if (appraisal.getAppointmentType().equals(AppointmentType.CLASSIFIED_IT) &&
                 emailType.getType().contains("signature")) {
             mailCC = "reviewer";

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/util/Mailer.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/util/Mailer.java
@@ -130,6 +130,11 @@ public class Mailer implements MailerInterface {
         String mailCC = emailType.getCc();
         String mailBCC = emailType.getBcc();
 
+        if (appraisal.getAppointmentType().equals(AppointmentType.CLASSIFIED_IT) &&
+                emailType.getType().contains("signature")) {
+            mailCC = "reviewer";
+        }
+
         if (mailTo != null && !mailTo.equals("")) {
             String[] to = getRecipients(mailTo, appraisal);
             if (to != null && to.length != 0) {


### PR DESCRIPTION
EV-98

The BC reviewers need to be notified after the supervisor has set
the recommended increase value. The easiest way to do it was to CC
the reviewers after the supervisor released the evaluation for
signature.
