### PR TITLE
Add new column to ratings table

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/hbm/Rating.hbm.xml
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/hbm/Rating.hbm.xml
@@ -7,6 +7,7 @@
         <id name="id" type="integer" column="ID"/>
 
         <property name="rate" type="integer" column="RATE"/>
+        <property name="name" type="string" column="NAME"/>
         <property name="description" type="string" column="DESCRIPTION"/>
         <property name="appointmentType" type="string" column="APPOINTMENT_TYPE"/>
     </class>

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/models/Rating.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/models/Rating.java
@@ -5,6 +5,8 @@ public class Rating extends Evals {
 
     private Integer rate;
 
+    private String name;
+
     private String description;
 
     private String appointmentType;
@@ -26,6 +28,14 @@ public class Rating extends Evals {
 
     public void setRate(Integer rate) {
         this.rate = rate;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getDescription() {

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/util/EvalsPDF.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/util/EvalsPDF.java
@@ -367,7 +367,7 @@ public class EvalsPDF {
         PdfPTable ratingTable = new PdfPTable(ratingMaxCols);
         PdfPCell emptyLeftCol = new PdfPCell();
         emptyLeftCol.setBorder(Rectangle.NO_BORDER);
-        emptyLeftCol.setRowspan(4);
+        emptyLeftCol.setRowspan(ratings.size());
         ratingTable.addCell(emptyLeftCol);
         ratingTable.setWidthPercentage(100f);
         PdfPCell cell;
@@ -394,7 +394,11 @@ public class EvalsPDF {
             } else {
                 ratingTable.addCell(uncheckedBox);
             }
-            cell = new PdfPCell(new Paragraph(rating.getDescription(), FONT_10));
+            String ratingText = rating.getName();
+            if (rating.getDescription() != null) {
+                ratingText += rating.getDescription();
+            }
+            cell = new PdfPCell(new Paragraph(ratingText, FONT_10));
             cell.setColspan(ratingMaxCols - 2);
             cell.setBorder(Rectangle.NO_BORDER);
             ratingTable.addCell(cell);
@@ -655,12 +659,16 @@ public class EvalsPDF {
 
         c = new Chunk(resource.getString("appraisal-rating")+": ", INFO_FONT);
         p = new Paragraph(c);
-        String rating = "";
+        String ratingText = "";
         boolean displayRating = StringUtils.containsAny(permRule.getEvaluation(), "ev");
         if (appraisal.getRating() != null && displayRating) {
-            rating = appraisal.getRating().toString();
+            for (Rating rating : ratings) {
+                if (appraisal.getRating().equals(rating.getRate())) {
+                    ratingText = rating.getName();
+                }
+            }
         }
-        c = new Chunk(rating, FONT_BOLD_11);
+        c = new Chunk(ratingText, FONT_BOLD_11);
         p.add(c);
         cell = new PdfPCell(p);
         cell.setPaddingLeft(4);

--- a/docroot/jsp/appraisals/evaluation.jsp
+++ b/docroot/jsp/appraisals/evaluation.jsp
@@ -34,7 +34,7 @@
                 <c:if test="${permissionRule.evaluation == 'v'}">
                     disabled="disabled"
                 </c:if> />
-                <label for="<portlet:namespace />appraisal.rating-${rating.rate}">${rating.description}</label><br />
+                <label for="<portlet:namespace />appraisal.rating-${rating.rate}">${rating.name}${rating.description}</label><br />
             </c:forEach>
         </fieldset>
 

--- a/docroot/jsp/appraisals/info.jsp
+++ b/docroot/jsp/appraisals/info.jsp
@@ -42,7 +42,11 @@
                     </td>
                     <td><em><liferay-ui:message key="appraisal-rating"/>:</em>
                         <c:if test="${not empty appraisal.rating and (permissionRule.evaluation == 'v' or permissionRule.evaluation == 'e')}">
-                            <c:out value="${appraisal.rating}" />
+                            <c:forEach var="rating" items="${ratings}">
+                                <c:if test="${appraisal.rating == rating.rate}">
+                                    <c:out value="${rating.name}" />
+                                </c:if>
+                            </c:forEach>
                         </c:if>
                     </td>
                 </tr>

--- a/sql-updates/2.0.2.sql
+++ b/sql-updates/2.0.2.sql
@@ -63,6 +63,7 @@ insert into configurations values(pass_seq.nextval, 'configuration', 'enableProf
 CREATE TABLE ratings (
     ID NUMBER(11) NOT NULL,
     RATE NUMBER(3) NOT NULL,
+    NAME VARCHAR2(64 CHAR),
     DESCRIPTION VARCHAR2(512 CHAR),
     APPOINTMENT_TYPE VARCHAR2(45 CHAR)
 );


### PR DESCRIPTION
EV-135
- The name column will store a shorter name for the rating.
- The name is displayed on the top table of the pdf
- the rating list/selection under evaluation shows the name along with
  the description for the rating.
