### PR TITLE
Once professional evaluations are created clear cache

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/hibernate/AppraisalMgr.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/hibernate/AppraisalMgr.java
@@ -154,6 +154,8 @@ public class AppraisalMgr {
         for (Job shortJob : jobsWithoutActiveEvaluations) {
             appraisals.add(createAppraisal(shortJob, startDate, Appraisal.TYPE_ANNUAL));
         }
+        Session session = HibernateUtil.getCurrentSession();
+        session.flush(); // force the records to be persisted in the db so that they can be picked up by home view
 
         return appraisals;
     }

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/AppraisalsAction.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/AppraisalsAction.java
@@ -1297,9 +1297,9 @@ public class AppraisalsAction implements ActionInterface {
         logger.log(Logger.INFORMATIONAL, "Initiated professional faculty evaluations", loggingMsg);
         SessionMessages.add(request, "prof-faculty-create-evals-success");
 
-        // refresh cached list of evaluations in supervisor home view
-        List<Appraisal> appraisals = actionHelper.getMyTeamActiveAppraisals();
-        appraisals.addAll(newAppraisals);
+        // clear out cached list of evaluations in supervisor home view. display method will re-build cache
+        PortletSession session = ActionHelper.getSession(request);
+        session.removeAttribute(ActionHelper.MY_TEAMS_ACTIVE_APPRAISALS);
 
         return homeAction.display(request, response);
     }


### PR DESCRIPTION
EV-142

Previously, the code was just adding the new records to the my team
evaluation list. It now just clears the existing list of records and
generates it again. This is the easiest way to update the list.
