### PR TITLE
Check appraisalStep before fetching emailType

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/AppraisalsAction.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/AppraisalsAction.java
@@ -515,7 +515,7 @@ public class AppraisalsAction implements ActionInterface {
      */
     private EmailType getEmailType() throws Exception {
         // the backend is going to send the email
-        if (appraisalStep.getEmailType() == null) {
+        if (appraisalStep == null || appraisalStep.getEmailType() == null) {
             return null;
         }
 


### PR DESCRIPTION
EV-147

The getEmailType method wasn't checking whether or not the
appraisalStep object was null before fetching the emailType.
