### PR TITLE
Fix escaping issues on a couple of emails

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/Email.properties
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/Email.properties
@@ -58,7 +58,7 @@ email_goalsApprovalDue_body=The performance goals for employee {0}, position {1}
   are ready for your approval. Before approving these goals, please have a discussion with your employee to ensure \
   these goals are achievable, realistic, and appropriate to the employee''s position duties.  You may require the \
   employee to modify the goals via EvalS if you so desire.  Once the goals are finalized you will need to approve \
-  the goals in the EvalS system.  This action is (was) due on {3}.
+  the goals in the EvalS system.  This action is due on {3}.
 email_goalsApprovalOverdue_subject=Action Required: Employee Performance Evaluation Goals approval Overdue
 #{0} = employee name, {1} = job title, {2} = review period, {3} = goals approval due date.
 email_goalsApprovalOverdue_body=The approval for goals for employee {0}, position {1} for the {2} review period was due \


### PR DESCRIPTION
EV-152 EV-148

The goalsApprovalDue and releaseDue emails had apostrophes that weren't
escaped properly. This was preventing some of the variables from being
inserted properly into the message.
