### PR TITLE
Set the status correctly when creating a record

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/backend/BackendMgr.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/backend/BackendMgr.java
@@ -452,8 +452,13 @@ public class BackendMgr {
             appraisal = AppraisalMgr.createAppraisal(job, startDate, type);
         }
 
-        if (appraisal != null)
-        {
+        if (appraisal != null) {
+            // update status if needed
+            String newStatus = appraisal.getNewStatus(configMap);
+            if (newStatus != null) {
+                appraisal.setStatus(newStatus);
+            }
+
             // create salary object if needed
             if (appraisal.getIsSalaryUsed()) {
                 AppraisalMgr.createOrUpdateSalary(appraisal, configMap);


### PR DESCRIPTION
EV-140

The status of newly created evaluation records was always goalsDue.
When the records were created late due to data errors or other
scenarios, the end users were getting goalsDue emails which was
not correct.
