### PR TITLE
Check that the admin buffer is not empty

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/backend/BackendMgr.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/backend/BackendMgr.java
@@ -1214,11 +1214,13 @@ public class BackendMgr {
 
         // Write the admin file.
         StringBuffer adminBuffer = adminStringWriter.getBuffer();
-        adminBuffer.insert(0, headerRow); // insert header row for admin
-        PrintWriter adminOut = new PrintWriter(getLateReportFilePath("OHR"));
-        adminOut.print(adminBuffer.toString());
-        adminOut.close();
-        adminWriter.close();
+        if (adminBuffer.length() != 0) {
+            adminBuffer.insert(0, headerRow); // insert header row for admin
+            PrintWriter adminOut = new PrintWriter(getLateReportFilePath("OHR"));
+            adminOut.print(adminBuffer.toString());
+            adminOut.close();
+            adminWriter.close();
+        }
     }
 
     private String getLateReportFilePath(String bcName) {


### PR DESCRIPTION
EV-164

When generating the late report for admin users, check that the
admin buffer is not empty. This use case will never happer in real
life.
