### PR TITLE
Data not loaded caused review due date error

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/ActionHelper.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/ActionHelper.java
@@ -661,6 +661,7 @@ public class ActionHelper {
                     if (appraisalStatus.equals(Appraisal.STATUS_GOALS_REACTIVATION_REQUESTED) ||
                             appraisalStatus.equals(Appraisal.STATUS_GOALS_REACTIVATED) ||
                             appraisalStatus.equals(Appraisal.STATUS_EMPLOYEE_REVIEW_DUE)) {
+                        appraisal = AppraisalMgr.getAppraisal(appraisal.getId());
                         appraisalStatus += "Expiration";
                     }
                     configuration = ConfigurationMgr.getConfiguration(configurationMap, appraisalStatus,


### PR DESCRIPTION
EV-162

The required action that checks the review due date, now loads the
appraisal record. The data used to check the property was null before
which was causing the required action due date to be incorrect.
