### PR TITLE
Zero out the time for professional faculty evals

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/AppraisalsAction.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/AppraisalsAction.java
@@ -1277,7 +1277,7 @@ public class AppraisalsAction implements ActionInterface {
         initialize(request);
         Integer year = ParamUtil.getInteger(request, "year");
         Integer month = ParamUtil.getInteger(request, "month");
-        DateTime startDate = new DateTime().withDate(year, month, 1);
+        DateTime startDate = new DateTime().withDate(year, month, 1).withTimeAtStartOfDay();
 
         // Logging information
         EvalsLogger logger = (EvalsLogger) actionHelper.getPortletContextAttribute("log");


### PR DESCRIPTION
EV-166

When specifying the start date for professional faculty evaluations,
the code was just copying the current time instead of zero-ing it out.
