### PR TITLE
Fix UI issue during auto-save

### DIFF
--- a/docroot/jsp/appraisals/appraisal.js
+++ b/docroot/jsp/appraisals/appraisal.js
@@ -78,6 +78,9 @@ jQuery(document).ready(function() {
       data: data,
       success: function(msg) {
         if (msg == "success") {
+          // remove any existing success messages from previous auto-save draft or manually saving draft
+          jQuery('.portlet-msg-success').remove();
+
           jQuery("#<portlet:namespace />flash").html(
               '<span class="portlet-msg-success"><liferay-ui:message key="draft-autosaved"/></span>'
           );


### PR DESCRIPTION
EV-172

The auto-save js code was adding some special css classes to be used
for the auto-save pop-up div. When the user manually saved draft, a
draft save message was already present. This caused the form to be
displayed incorrectly.
