### PR TITLE
Copy all properties from trial assessment

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/models/Assessment.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/models/Assessment.java
@@ -211,6 +211,8 @@ public class Assessment extends Evals implements Comparable<Assessment> {
         newAssessment.setSupervisorResult(trialAssessment.getSupervisorResult());
         newAssessment.setModifiedDate(new Date());
         newAssessment.setSequence(trialAssessment.getSequence());
+        newAssessment.setDeleterPidm(trialAssessment.getDeleterPidm());
+        newAssessment.setDeleteDate(trialAssessment.getDeleteDate());
 
         // copy assessment criteria objects for this new assessment
         for (AssessmentCriteria trialAssessmentCriteria : trialAssessment.getAssessmentCriteria()) {


### PR DESCRIPTION
EV-184

The delete\* properties in assessments weren't being copied when the
first annual evaluation was created.
