### PR TITLE
Fix cancel button in criteria/notices edit page

### DIFF
--- a/docroot/jsp/criteria/add.jsp
+++ b/docroot/jsp/criteria/add.jsp
@@ -9,6 +9,11 @@
     <c:set var="titleKey" value="criteria-edit" scope="request"/>
 </c:if>
 
+<portlet:renderURL windowState="<%= WindowState.MAXIMIZED.toString() %>"  var="listCriteria" escapeXml="false">
+    <portlet:param name="action" value="list"/>
+    <portlet:param name="controller" value="CriteriaAreasAction"/>
+</portlet:renderURL>
+
 <%
 List appointmentTypes = (List) renderRequest.getAttribute("appointmentTypes");
 %>
@@ -51,9 +56,7 @@ List appointmentTypes = (List) renderRequest.getAttribute("appointmentTypes");
         
         <input type="submit" value="<liferay-ui:message key="save" />" />
         <input type="button" class="cancel" value="<liferay-ui:message key="cancel" />"
-            onClick="location.href = '<portlet:renderURL windowState="<%= WindowState.MAXIMIZED.toString() %>">
-            <portlet:param name="action" value="list"/>
-            <portlet:param name="controller" value="CriteriaAreasAction"/></portlet:renderURL>';" />
+            onClick="location.href = '<%=renderResponse.encodeURL(listCriteria.toString())%>';" />
     </form>
 </div>
 

--- a/docroot/jsp/notices/edit.jsp
+++ b/docroot/jsp/notices/edit.jsp
@@ -1,5 +1,10 @@
 <%@ include file="/jsp/init.jsp" %>
 
+<portlet:renderURL windowState="<%= WindowState.MAXIMIZED.toString() %>"  var="listNotices" escapeXml="false">
+    <portlet:param name="action" value="list"/>
+    <portlet:param name="controller" value="NoticeAction"/>
+</portlet:renderURL>
+
 <jsp:useBean id="notice" class="edu.osu.cws.evals.models.Notice" scope="request" />
 
 
@@ -22,9 +27,7 @@
 
     <input type="submit" value="<liferay-ui:message key="save" />" />
     <input type="button" class="cancel" value="<liferay-ui:message key="cancel" />"
-    onClick="location.href = '<portlet:renderURL windowState="<%= WindowState.MAXIMIZED.toString() %>">
-    <portlet:param name="action" value="list"/>
-    <portlet:param name="controller" value="NoticeAction"/></portlet:renderURL>';" />
+    onClick="location.href = '<%=renderResponse.encodeURL(listNotices.toString())%>';" />
     </form>
 </div>
 


### PR DESCRIPTION
EV-199

There was a js error in the onclick event used by criteria/notices
edit. The portlet:render/actionURL tags are inserting line breaks.
I just defined the url as a variable before and then called toString
on it.
