### PR TITLE
JS bug prevent evaluation close action

### DIFF
--- a/docroot/jsp/appraisals/closeout.jsp
+++ b/docroot/jsp/appraisals/closeout.jsp
@@ -46,7 +46,7 @@
 jQuery("#<portlet:namespace />fm").submit(function() {
     var portlet_namespace = '<portlet:namespace />';
     var json_data = { id: ${appraisal.id}};
-    json_data.closeOutReasonId = jQuery("input[name=" + portlet_namespace + "appraisal.closeOutReasonId]:checked").val();
+    json_data.closeOutReasonId = jQuery("input[name=\"" + portlet_namespace + "appraisal.closeOutReasonId\"]:checked").val();
     // button clicked
     json_data.buttonClicked = jQuery("input[type=submit][clicked=true]").attr('name');
 


### PR DESCRIPTION
EV-201

There were some missing quotes needed in a line of js code. With a
newer version of jQuery, the js checking got stricter.
