### PR TITLE
Allow serveResource to fetch employee at login

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/ActionHelper.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/ActionHelper.java
@@ -51,13 +51,27 @@ public class ActionHelper {
 
     private ResourceBundle bundle;
 
+    // Variable used to disable http/portlet session validation. Only set to false in testing mode
+    private boolean validateSession = true;
+
     public ActionHelper() { }
 
+    /**
+     * Constructor used mostly by EvalSPortlet to create an instance of this class and set the request, response
+     * objects as well as portlet context. If validateSession is false, the session won't be checked for validity.
+     *
+     * @param request                       PortletRequest
+     * @param response                      PortletResponse
+     * @param portletContext                PortletContext
+     * @param validateSession               Whether or not the portlet session should be checked for validity.
+     * @throws Exception
+     */
     public ActionHelper(PortletRequest request, PortletResponse response,
-                        PortletContext portletContext) throws Exception {
+                        PortletContext portletContext, boolean validateSession) throws Exception {
         this.request = request;
         this.response = response;
         this.portletContext = portletContext;
+        this.validateSession = validateSession;
         this.bundle = (ResourceBundle) portletContext.getAttribute("resourceBundle");
         setRequestMap();
         setLoggedOnUser();
@@ -72,12 +86,15 @@ public class ActionHelper {
     PortletSession getSession() throws Exception {
         PortletSession session = request.getPortletSession(true);
 
-        if (!request.isRequestedSessionIdValid()) {
-            throw new Exception("Session is invalid.");
-        }
+        // Only validate session when it's needed
+        if (validateSession) {
+            if (!request.isRequestedSessionIdValid()) {
+                throw new Exception("Session is invalid.");
+            }
 
-        if (!isHttpSessionValid(request)) {
-            throw new Exception("HttpSession is invalid.");
+            if (!isHttpSessionValid(request)) {
+                throw new Exception("HttpSession is invalid.");
+            }
         }
 
         return session;

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/tests/EvalsPortletTests.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/tests/EvalsPortletTests.java
@@ -1,0 +1,49 @@
+package edu.osu.cws.evals.tests;
+
+import edu.osu.cws.evals.portlet.EvalsPortlet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.portlet.*;
+import java.io.PrintWriter;
+
+import static org.mockito.Mockito.*;
+
+@Test
+public class EvalsPortletTests {
+
+    private EvalsPortlet mockedEvalsPortlet;
+    private ResourceRequest mockedResourceRequest;
+    private ResourceResponse mockedResourceResponse;
+    private PortletContext mockedPortletContext;
+    private PortletSession mockedPortletSession;
+
+
+    @BeforeMethod
+    public void setup() throws Exception {
+        DBUnit dbunit = new DBUnit();
+        dbunit.seedDatabase();
+
+        mockedEvalsPortlet = spy(new EvalsPortlet());
+        mockedEvalsPortlet.setValidateSession(false);
+        mockedResourceRequest = mock(ResourceRequest.class);
+        mockedResourceResponse = mock(ResourceResponse.class);
+        mockedPortletSession = mock(PortletSession.class);
+        mockedPortletContext = mock(PortletContext.class);
+        doReturn(mockedPortletContext).when(mockedEvalsPortlet).getPortletContext();
+        when(mockedResourceRequest.isRequestedSessionIdValid()).thenReturn(true);
+        when(mockedResourceRequest.getPortletSession(true)).thenReturn(mockedPortletSession);
+        when(mockedResourceResponse.getWriter()).thenReturn(new PrintWriter("test"));
+    }
+
+    public void shouldSetUsernameInServeResource() throws Exception {
+        String username = "barlowc";
+        when(mockedResourceRequest.getResourceID()).thenReturn("testing");
+        when(mockedPortletSession.getAttribute("onidUsername")).thenReturn(username);
+
+        mockedEvalsPortlet.serveResource(mockedResourceRequest, mockedResourceResponse);
+        verify(mockedResourceRequest).getResourceID();
+        verify(mockedPortletSession).getAttribute("loggedOnUser");
+        assert mockedEvalsPortlet.getActionHelper().getLoggedOnUser().getOnid().equals(username);
+    }
+}


### PR DESCRIPTION
EV-203

The serveResource was assuming that the loggedOnUser was cached in
session. When this wasn't the case, it was throwing an exception
because the hibernate session was started too late in the method.
Added unit test to check that the employee object is fetched properly
by EvalsPortlet.serveResource.
