### PR TITLE
Fix NPE bug in getPermissionRule

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/hibernate/PermissionRuleMgr.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/hibernate/PermissionRuleMgr.java
@@ -50,14 +50,16 @@ public class PermissionRuleMgr {
     public static PermissionRule getPermissionRule(HashMap<String, PermissionRule> permissionRuleMap,
                                                    Appraisal appraisal, String role) throws Exception {
         String status = appraisal.getStatus();
-        //Permission rules for statuses “archivedCompleted” and “archivedClose” are the same as “completed” and
-        // “closed” respectively
-        if (status.contains("archived")) {
-            status = status.replace("archived", "").toLowerCase();
-        }
+        if (status != null) {
+            //Permission rules for statuses “archivedCompleted” and “archivedClose” are the same as “completed” and
+            // “closed” respectively
+            if (status.contains("archived")) {
+                status = status.replace("archived", "").toLowerCase();
+            }
 
-        // The permission rules of "Overdue" and "Due" are the same. "Overdue" status are not present in the db.
-        status = status.replace("Overdue", "Due");
+            // The permission rules of "Overdue" and "Due" are the same. "Overdue" status are not present in the db.
+            status = status.replace("Overdue", "Due");
+        }
         String appointmentType = appraisal.getJob().getAppointmentType().replace(" ", "");
         String actionKeyPrefix = status + "-" + role + "-";
 

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/tests/PermissionRulesTest.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/tests/PermissionRulesTest.java
@@ -81,6 +81,16 @@ public class PermissionRulesTest {
         assert rule == null;
     }
 
+    public void shouldReturnNullWhenStatusIsNotSet() throws Exception {
+        HashMap<String, PermissionRule> rules = getTestRuleMap();
+        Appraisal appraisal = new Appraisal();
+        appraisal.setJob(new Job());
+        appraisal.getJob().setAppointmentType("Professional Faculty");
+
+        PermissionRule rule = PermissionRuleMgr.getPermissionRule(rules, appraisal, "supervisor");
+        assert rule == null;
+    }
+
     private HashMap<String, PermissionRule> getTestRuleMap() {
         HashMap<String, PermissionRule> rules = new HashMap<String, PermissionRule>();
 


### PR DESCRIPTION
EV-513

The getPermissionRule method checks that the status is not null before
using it.
