### PR TITLE
Fix bug preventing deleting of goals

### DIFF
--- a/docroot/jsp/appraisals/appraisal.js
+++ b/docroot/jsp/appraisals/appraisal.js
@@ -547,7 +547,7 @@ jQuery(document).ready(function() {
    */
   function isAssessmentDeleted() {
     // find the delete flag hidden input
-    var deleteFlag = jQuery(this).find('input:hidden').filter(function(index) {
+    var deleteFlag = jQuery(this).find('input[type=hidden]').filter(function(index) {
         return jQuery(this).attr('class').indexOf('appraisal-assessment-deleted-') == 0;
     });
     return deleteFlag.val() != 0


### PR DESCRIPTION
EV-514

When goals are deleted and the evaluation goals are submitted, it
was causing a js error. The jQuery filter used to find the deleted
hidden input was too broad for the newer version of jQuery. Modified
the find filter to specify that the hidden elements are supposed to be
of input hidden.
