### PR TITLE
Limit percent increase when salary is close to upper limit

### DIFF
--- a/docroot/jsp/appraisals/salary.jsp
+++ b/docroot/jsp/appraisals/salary.jsp
@@ -121,6 +121,11 @@
          * @return {String}
          */
         function getSalaryAfterIncrease() {
+            var rating = jQuery('input:radio[name=<portlet:namespace />appraisal.rating]:checked').val();
+            if (rating == 3) {
+                return formatCurrency(${appraisal.salary.current});
+            }
+
             var increasePercentage = jQuery(".osu-cws input.recommended-salary").val();
             if (!(increasePercentage >= 0 && increasePercentage <= 999)) {
                 increasePercentage = 0;
@@ -144,11 +149,9 @@
                     salaryAfterIncrease = salary_low;
                 }
             }
-            salaryAfterIncrease = salaryAfterIncrease.toFixed(2); // round to 2 decimals
 
-            // format salary
-            var fmtSalary = salaryAfterIncrease.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,");
-            return '$' + fmtSalary;
+            salaryAfterIncrease = salaryAfterIncrease.toFixed(2); // round to 2 decimals
+            return formatCurrency(salaryAfterIncrease);
         }
 
         /**

--- a/docroot/jsp/footer.jsp
+++ b/docroot/jsp/footer.jsp
@@ -69,4 +69,15 @@
         });
         jQuery("span.evals-show-confirm a").attr("onClick","");
     });
+
+    /**
+     * Format value into currency with two decimals and the $ sign.
+     *
+     * @param value
+     * @returns {string}
+     */
+    function formatCurrency(value) {
+        var fmtValue = value.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,");
+        return '$' + fmtValue;
+    }
 </script>


### PR DESCRIPTION
EV-186

In the front end js refreshes the percent increase to reflect the
actual increase allowed since the salary cannot go above upper limit.
The backend validates the percent increase as well and allows an
increase below the valid ranges only when the current salary is
close to the upper limit.
