### PR TITLE
openTrialAppraisalExists didn't check archived evaluations

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/hibernate/AppraisalMgr.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/hibernate/AppraisalMgr.java
@@ -693,7 +693,7 @@ public class AppraisalMgr {
                 "where appraisal.job.employee.id = :pidm and appraisal.job.positionNumber = :positionNumber " +
                 "and appraisal.job.suffix = :suffix and appraisal.type = :type " +
                 "and (appraisal.status != 'closed' AND  appraisal.status != 'completed' AND " +
-                "appraisal.status != 'archived')";
+                "appraisal.status not like 'archived%')";
 
         Iterator resultMapIter = session.createQuery(query)
                 .setInteger("pidm", job.getEmployee().getId())

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/tests/AppraisalsTest.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/tests/AppraisalsTest.java
@@ -325,25 +325,24 @@ public class AppraisalsTest {
 
         List<Appraisal> teamActiveAppraisals = AppraisalMgr.getMyTeamsAppraisals(pidm, true,
                 null, null, appointmentTypes);
-        assert teamActiveAppraisals.size() == 7 : "Invalid size of team active appraisals";
+        assert teamActiveAppraisals.size() == 8 : "Invalid size of team active appraisals";
         for (Appraisal ap : teamActiveAppraisals) {
-            assert ap.getId() != 0 :
-                    "id should be present in list of team appraisals";
-            //@todo: should this be use jobTitle instead? check my notes
-            assert ap.getJob().getJobTitle() != null : "" +
-                    "job title should be present in list of team appraisals";
-            assert ap.getStartDate() != null :
-                    "start date should be present in list of team appraisals";
-            assert ap.getEndDate() != null :
-                    "end date should be present in list of team appraisals";
-            assert ap.getStatus() != null :
-                    "status should be present in list of team appraisals";
-            assert ap.getJob().getEmployee().getFirstName() != null :
-                    "employee first name should be present in list of team appraisals";
-            assert ap.getJob().getEmployee().getLastName() != null :
-                    "employee last name should be present in list of team appraisals";
-            assert ap.getJob().getAppointmentType() != null :
-                    "appointment type name should be present in list of team appraisals";
+            if (ap.getId() != 0) {
+                assert ap.getJob().getJobTitle() != null : "" +
+                        "job title should be present in list of team appraisals";
+                assert ap.getStartDate() != null :
+                        "start date should be present in list of team appraisals";
+                assert ap.getEndDate() != null :
+                        "end date should be present in list of team appraisals";
+                assert ap.getStatus() != null :
+                        "status should be present in list of team appraisals";
+                assert ap.getJob().getEmployee().getFirstName() != null :
+                        "employee first name should be present in list of team appraisals";
+                assert ap.getJob().getEmployee().getLastName() != null :
+                        "employee last name should be present in list of team appraisals";
+                assert ap.getJob().getAppointmentType() != null :
+                        "appointment type name should be present in list of team appraisals";
+            }
         }
     }
 
@@ -560,7 +559,6 @@ public class AppraisalsTest {
         //@todo: test appraisalExists
     }
 
-    @Test(groups={"pending"})
     public void shouldDetectIfAJobHasAnOpenTrialAppraisal() throws Exception {
         Job job = new Job();
         Employee employee = new Employee();
@@ -576,6 +574,17 @@ public class AppraisalsTest {
 
         job.setPositionNumber("4444");
         assert AppraisalMgr.openTrialAppraisalExists(job);
+    }
+
+    public void shouldNotConsiderArchivedAsOpenTrialAppraisals() throws Exception {
+        Job job = new Job();
+        Employee employee = new Employee();
+        employee.setId(12345);
+        job.setEmployee(employee);
+        job.setPositionNumber("7777");
+        job.setSuffix("00");
+
+        assert !AppraisalMgr.openTrialAppraisalExists(job);
     }
 
     @Test(groups={"pending"})

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/tests/JobsTest.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/tests/JobsTest.java
@@ -147,7 +147,7 @@ public class JobsTest {
     public void getJobsShouldReturnJobs() throws Exception {
         assert JobMgr.getJobs(56198).size() == 1;
         assert JobMgr.getJobs(111).size() == 0;
-        assert JobMgr.getJobs(12345).size() == 4;
+        assert JobMgr.getJobs(12345).size() == 5;
     }
 
     public void shouldReturnBusinessCenter() throws Exception {
@@ -239,7 +239,7 @@ public class JobsTest {
 
     public void searchShouldAcceptOsuid() throws Exception {
         List<Job> jobs = JobMgr.search("931421235", null, 0);
-        assert jobs.size() == 4;
+        assert jobs.size() == 5;
 
         jobs = JobMgr.search("931421234", null, 0);
         assert jobs.size() == 1;
@@ -272,12 +272,12 @@ public class JobsTest {
         assert jobs.size() == 0;
 
         jobs = JobMgr.findByName("Jo", null, 0);
-        assert jobs.size() == 6;
+        assert jobs.size() == 7;
     }
 
     public void searchByNameShouldAcceptLastNameOnly() throws Exception {
         List<Job> jobs = JobMgr.findByName("Cedeno", null, 0);
-        assert jobs.size() == 4;
+        assert jobs.size() == 5;
 
         jobs = JobMgr.findByName("Bond", null, 0);
         assert jobs.size() == 0;

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/tests/full.xml
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/tests/full.xml
@@ -97,6 +97,19 @@
               overdue="0"
   />
 
+  <appraisals ID="9"
+              START_DATE="2009-05-14"
+              END_DATE="2010-05-10"
+              STATUS="archivedCompleted"
+              JOB_PIDM="12345"
+              POSITION_NUMBER="7777"
+              JOB_SUFFIX="00"
+              CREATE_DATE="2010-05-01"
+              EVALUATION_SUBMIT_DATE="2011-03-01"
+              TYPE="trial"
+              overdue="0"
+          />
+
   <goals_versions ID="1" CREATE_DATE="2011-04-10 20:16:48.0" APPRAISAL_ID="1"/>
   <goals_versions ID="2" CREATE_DATE="2011-04-10 20:16:48.0" APPRAISAL_ID="2"/>
   <goals_versions ID="3" CREATE_DATE="2011-04-10 20:16:48.0" APPRAISAL_ID="5"/>
@@ -536,6 +549,28 @@
             PYVPASJ_SAL_STEP="0"
             PYVPASJ_TRIAL_IND="6"
             PYVPASJ_ANNUAL_IND="12"
+            PYVPASJ_EVAL_DATE="2010-01-30"
+            PYVPASJ_ORGN_DESC="testing"/>
+
+    <jobs
+            PYVPASJ_PIDM="12345"
+            PYVPASJ_SUPERVISOR_PIDM="12467"
+            PYVPASJ_SUPERVISOR_POSN="1234"
+            PYVPASJ_SUPERVISOR_SUFF="00"
+            PYVPASJ_DESC="super hero"
+            PYVPASJ_POSN="7777"
+            PYVPASJ_SUFF="00"
+            PYVPASJ_ECLS_CODE="kjlkjlk"
+            PYVPASJ_APPOINTMENT_TYPE="Classified"
+            PYVPASJ_BEGIN_DATE="2011-05-14"
+            PYVPASJ_BCTR_TITLE="UABC"
+            PYVPASJ_ORGN_CODE_TS="test"
+            PYVPASJ_STATUS="A"
+            PYVPASJ_PCLS_CODE="test"
+            PYVPASJ_SAL_GRADE="0"
+            PYVPASJ_SAL_STEP="0"
+            PYVPASJ_TRIAL_IND="9"
+            PYVPASJ_ANNUAL_IND="18"
             PYVPASJ_EVAL_DATE="2010-01-30"
             PYVPASJ_ORGN_DESC="testing"/>
 


### PR DESCRIPTION
EV-532

The method openTrialAppraisalExists only considered 'closed' and
'archived' as non-open status. It now checks 'archived%' as the
status for archived evaluations.
