### PR TITLE
Fix supervisor signature

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/models/Appraisal.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/models/Appraisal.java
@@ -928,7 +928,10 @@ public class Appraisal extends Evals implements Comparable<Appraisal> {
     }
 
     /**
-     * Loads lazy associations
+     * Loads lazy associations. This is needed because Hibernate doesn't load all the
+     * needed object associations by default. If the first time, they are used is in the
+     * jsp, it will throw an error since the db session will have been closed at that
+     * point.
      */
     public void loadLazyAssociations() {
         job.toString();
@@ -941,6 +944,9 @@ public class Appraisal extends Evals implements Comparable<Appraisal> {
         }
         if (getCloseOutReason() != null) {
             getCloseOutReason().getReason();
+        }
+        if (evaluator != null) {
+            evaluator.getName();
         }
 
         // iterate over goalVersions to load data

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/util/EvalsPDF.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/util/EvalsPDF.java
@@ -212,7 +212,10 @@ public class EvalsPDF {
 
         if (appraisal.getReleaseDate() != null) {
             DateTime releaseDate = new DateTime(appraisal.getReleaseDate()).withTimeAtStartOfDay();
-            String supervisorName = job.getSupervisor().getEmployee().getName();
+            String supervisorName = "";
+            if (appraisal.getEvaluator() != null) {
+                supervisorName = appraisal.getEvaluator().getName();
+            }
             String supervisorSignDate = releaseDate.toString(Constants.DATE_FORMAT);
             supervisorCell.addElement(new Phrase(supervisorName, INFO_FONT));
             supervisorDateCell.addElement(new Phrase(supervisorSignDate, INFO_FONT));

--- a/docroot/jsp/appraisals/appraisal.jsp
+++ b/docroot/jsp/appraisals/appraisal.jsp
@@ -268,7 +268,10 @@
                 </c:when>
                 <c:when test="${permissionRule.rebuttalRead == 'v' and not empty appraisal.supervisorRebuttalRead}">
                     <p><strong><liferay-ui:message key="appraisal-supervisor-${rebuttalType}-read" />
-                    ${appraisal.job.supervisor.employee.name} on
+                        <c:if test="${not empty appraisal.evaluator}">
+                            ${appraisal.evaluator.name}
+                        </c:if>
+                        on
                     <fmt:formatDate value="${appraisal.supervisorRebuttalRead}" pattern="MM/dd/yy"/> at
                     <fmt:formatDate value="${appraisal.supervisorRebuttalRead}" pattern="h:m a"/>
                     </strong></p>

--- a/docroot/jsp/appraisals/evaluation.jsp
+++ b/docroot/jsp/appraisals/evaluation.jsp
@@ -61,7 +61,9 @@
                 <p>
                     <c:if test="${not empty appraisal.releaseDate}">
                         <liferay-ui:message key="appraisal-signed" />
-                        ${appraisal.job.supervisor.employee.name}
+                        <c:if test="${not empty appraisal.evaluator}">
+                            ${appraisal.evaluator.name}
+                        </c:if>
                         <fmt:formatDate value="${appraisal.releaseDate}" pattern="MM/dd/yy h:m a"/>
                     </c:if>
                 </p>


### PR DESCRIPTION
EV-586

EvalS was using the current job's supervisor to specify who had signed
the evaluation. The code now uses the evaluator who correctly signed it.