### PR TITLE
Execute js prof. faculty effect when needed

### DIFF
--- a/docroot/jsp/appraisals/appraisal.js
+++ b/docroot/jsp/appraisals/appraisal.js
@@ -1,6 +1,7 @@
 jQuery(document).ready(function() {
 
   // professional faculty start-here animation:
+  <c:if test="${!empty profFacultyMsg and appraisal.job.appointmentType == 'Professional Faculty'}">
   jQuery('.evals-prof-faculty-start').siblings().fadeTo("slow", 0.2);
   setTimeout(function() { endStartAnimation() }, 3000);
 
@@ -8,6 +9,7 @@ jQuery(document).ready(function() {
     jQuery('.evals-prof-faculty-start').siblings().fadeTo("slow", 1);
     setTimeout(function() { jQuery('.evals-prof-faculty-start span.evals-arrow').effect("shake", 1000)}, 1000);
   }
+  </c:if>
 
   // Handle acknowledge appraisal rebuttal read by supervisor
   jQuery(".pass-appraisal-rebuttal").hide();


### PR DESCRIPTION
EV-588

The professional faculty js effect to highlight the documentation was
being executed in all the evaluation forms. The newer version of jquery
is stricter and was returning a null causing a js error.