### PR TITLE
Google Charts changed the css used in their table

### DIFF
--- a/docroot/css/evals.css
+++ b/docroot/css/evals.css
@@ -372,7 +372,8 @@ tr.ui-state-highlight {
     font-weight: bold;
 }
 
-.osu-cws tr.google-header-row td {
+.osu-cws tr.google-header-row td,
+.osu-cws th.google-visualization-table-th {
     color: #fff;
 }
 


### PR DESCRIPTION
LT-39

Google Charts changed the css they used to render their js table.
This meant that our css didn't properly target the table anymore.