### PR TITLE
Fix defect that deleted increase incorrectly

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/backend/BackendMgr.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/backend/BackendMgr.java
@@ -488,7 +488,17 @@ public class BackendMgr {
         return appraisal;
     }
 
-    private boolean shouldUpdateSalaryInfo(Appraisal appraisal) throws Exception{
+    /**
+     * Whether or not the salary record should be updated
+     * @param appraisal
+     * @return
+     * @throws Exception
+     */
+    public boolean shouldUpdateSalaryInfo(Appraisal appraisal) throws Exception{
+        if (appraisal.getSalary().getIncrease() != null) {
+            return false;
+        }
+
         Configuration config = ConfigurationMgr.getConfiguration(configMap, "appraisalDue",
                 appraisal.getAppointmentType());
         DateTime dueDate = EvalsUtil.getDueDate(appraisal, config);

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/backend/BackendMgr.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/backend/BackendMgr.java
@@ -489,9 +489,10 @@ public class BackendMgr {
     }
 
     /**
-     * Whether or not the salary record should be updated
-     * @param appraisal
-     * @return
+     * Whether or not the salary record should be updated in appraisal
+     *
+     * @param appraisal     Classified IT appraisal to check if salary should be updated
+     * @return boolean      True if salary is not set and appraisal is not due yet
      * @throws Exception
      */
     public boolean shouldUpdateSalaryInfo(Appraisal appraisal) throws Exception{

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/tests/BackendMgrTests.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/tests/BackendMgrTests.java
@@ -338,11 +338,9 @@ public class BackendMgrTests {
         appraisal.getSalaries().add(new Salary());
 
         // get instance and call updateAppraisal
+        BackendMgr mgr = getMgrInstance();
         Session session = HibernateUtil.getCurrentSession();
         Transaction tx = session.beginTransaction();
-        BackendMgr mgr = getMgrInstance();
-        session = HibernateUtil.getCurrentSession();
-        tx = session.beginTransaction();
 
         assert mgr.shouldUpdateSalaryInfo(appraisal) : "Should refresh since appraisal is due in one day";
 
@@ -361,7 +359,6 @@ public class BackendMgrTests {
         salary.setIncrease(7d); // set increase in salary object
         appraisal.getSalaries().add(salary); // add association back
         assert !mgr.shouldUpdateSalaryInfo(appraisal) : "Should not refresh since salary increase is set";
-
 
         tx.commit();
     }

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/tests/BackendMgrTests.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/tests/BackendMgrTests.java
@@ -327,6 +327,9 @@ public class BackendMgrTests {
     }
 
     public void shouldUpdateSalaryWhenAppraisalIsDue() throws Exception {
+        // The appraisal is due 60 days before the appraisal.endDate. By setting the end date to be 61
+        // days from today, makes it due in one day, 60 days from today means due today and 59 means
+        // it was due yesterday.
         Appraisal appraisal = new Appraisal();
         appraisal.setJob(new Job());
         appraisal.getJob().setAppointmentType(AppointmentType.CLASSIFIED_IT);

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/tests/full.xml
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/tests/full.xml
@@ -734,6 +734,16 @@
           ACTION=""
           APPOINTMENT_TYPE="Default"
           />
+  <configurations
+          ID="15"
+          SECTION="due-date"
+          NAME="appraisalDue"
+          SEQUENCE="6"
+          VALUE="60"
+          REFERENCE_POINT="end"
+          ACTION="subtract"
+          APPOINTMENT_TYPE="Default"
+          />
   <salaries
           ID="1"
           APPRAISAL_ID="8"


### PR DESCRIPTION
EV-205

* BackendMgr.shouldUpdateSalaryInfo was deleting and re-creating the
  salary row as long as the appraisal wasn't due
* shouldUpdateSalaryInfo now checks that the salary increase is not set
* Added tests for shouldUpdateSalaryInfo