### PR TITLE
Rename ranked flag in job table

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/hbm/Job.hbm.xml
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/hbm/Job.hbm.xml
@@ -33,7 +33,7 @@
         <property name="salaryHigh" type="double" column="PYVPASJ_HIGH"/>
         <property name="salaryCurrent" type="double" column="PYVPASJ_SALARY"/>
         <property name="salaryGrpCode" type="string" length="6" column="PYVPASJ_SGRP_CODE"/>
-        <property name="rankedFlag" type="boolean" column="PYVPASJ_RANKED_FLAG"/>
+        <property name="rankedFlag" type="boolean" column="PYVPASJ_INCLUDE_RANKED_FLAG"/>
 
         <many-to-one name="supervisor" class="edu.osu.cws.evals.models.Job" not-null="false" fetch="select">
             <column name="PYVPASJ_SUPERVISOR_PIDM"/>

--- a/docroot/WEB-INF/src/edu/osu/cws/evals/tests/full.xml
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/tests/full.xml
@@ -253,7 +253,7 @@
         PYVPASJ_ANNUAL_IND="0"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
   <jobs
         PYVPASJ_PIDM="12345"
         PYVPASJ_SUPERVISOR_PIDM="12467"
@@ -275,7 +275,7 @@
         PYVPASJ_ANNUAL_IND="18"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
   <jobs
         PYVPASJ_PIDM="12467"
         PYVPASJ_DESC="MU Supervisor"
@@ -294,7 +294,7 @@
         PYVPASJ_ANNUAL_IND="0"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
   <jobs
         PYVPASJ_PIDM="12345"
         PYVPASJ_SUPERVISOR_PIDM="56198"
@@ -316,7 +316,7 @@
         PYVPASJ_ANNUAL_IND="0"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
   <jobs
         PYVPASJ_PIDM="787812"
         PYVPASJ_SUPERVISOR_PIDM="8712359"
@@ -338,7 +338,7 @@
         PYVPASJ_ANNUAL_IND="0"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
   <jobs
         PYVPASJ_PIDM="8712359"
         PYVPASJ_SUPERVISOR_PIDM="990871"
@@ -360,7 +360,7 @@
         PYVPASJ_ANNUAL_IND="12"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
   <jobs
         PYVPASJ_PIDM="990871"
         PYVPASJ_DESC="Bar owner"
@@ -379,7 +379,7 @@
         PYVPASJ_ANNUAL_IND="18"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
   <jobs
         PYVPASJ_PIDM="56198"
         PYVPASJ_SUPERVISOR_PIDM="12345"
@@ -401,7 +401,7 @@
         PYVPASJ_ANNUAL_IND="12"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
     <jobs
         PYVPASJ_PIDM="56198"
         PYVPASJ_SUPERVISOR_PIDM="12345"
@@ -423,7 +423,7 @@
         PYVPASJ_ANNUAL_IND="12"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
     <jobs
         PYVPASJ_PIDM="56199"
         PYVPASJ_DESC="Bar owner"
@@ -442,7 +442,7 @@
         PYVPASJ_ANNUAL_IND="12"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
     <jobs
         PYVPASJ_PIDM="56199"
         PYVPASJ_DESC="Bar owner"
@@ -461,7 +461,7 @@
         PYVPASJ_ANNUAL_IND="12"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
 
     <jobs
             PYVPASJ_PIDM="74589"
@@ -486,7 +486,7 @@
             PYVPASJ_HIGH="4000"
             PYVPASJ_SALARY="2500"
             PYVPASJ_SGRP_CODE="123456"
-            PYVPASJ_RANKED_FLAG="0"/>
+            PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
 
     <jobs
         PYVPASJ_PIDM="60001"
@@ -506,7 +506,7 @@
         PYVPASJ_ANNUAL_IND="12"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
     <jobs
         PYVPASJ_PIDM="60002"
         PYVPASJ_DESC="Back to the history"
@@ -525,7 +525,7 @@
         PYVPASJ_ANNUAL_IND="12"
         PYVPASJ_EVAL_DATE="2010-01-30"
         PYVPASJ_ORGN_DESC="testing"
-        PYVPASJ_RANKED_FLAG="0"/>
+        PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
     <jobs
             PYVPASJ_PIDM="12345"
             PYVPASJ_SUPERVISOR_PIDM="56200"
@@ -547,7 +547,7 @@
             PYVPASJ_ANNUAL_IND="12"
             PYVPASJ_EVAL_DATE="2010-01-30"
             PYVPASJ_ORGN_DESC="testing"
-            PYVPASJ_RANKED_FLAG="1"/>
+            PYVPASJ_INCLUDE_RANKED_FLAG="1"/>
     <jobs
             PYVPASJ_PIDM="56200"
             PYVPASJ_POSN="C56123"
@@ -566,7 +566,7 @@
             PYVPASJ_ANNUAL_IND="12"
             PYVPASJ_EVAL_DATE="2010-01-30"
             PYVPASJ_ORGN_DESC="testing"
-            PYVPASJ_RANKED_FLAG="0"/>
+            PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
 
     <jobs
             PYVPASJ_PIDM="12345"
@@ -589,7 +589,7 @@
             PYVPASJ_ANNUAL_IND="18"
             PYVPASJ_EVAL_DATE="2010-01-30"
             PYVPASJ_ORGN_DESC="testing"
-            PYVPASJ_RANKED_FLAG="0"/>
+            PYVPASJ_INCLUDE_RANKED_FLAG="0"/>
 
   <permission_rules ID="1" STATUS="goalsDue" ROLE="employee" APPROVED_GOALS="e" ACTION_REQUIRED="goalsDue" APPOINTMENT_TYPE="Default"/>
   <permission_rules ID="2" STATUS="goalsDue" ROLE="immediate-supervisor" APPROVED_GOALS="e" APPOINTMENT_TYPE="Default"/>


### PR DESCRIPTION
EV-614

The db column was renamed for clarity. The pojo property has not been
renamed since we don't really know how this field will be used in the
future. This flag is more of a configuration setting for HR that is
managed via db logic.