### PR TITLE
Fix NPE in my appraisal actions

### DIFF
--- a/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/ActionHelper.java
+++ b/docroot/WEB-INF/src/edu/osu/cws/evals/portlet/ActionHelper.java
@@ -593,13 +593,15 @@ public class ActionHelper {
      * @throws Exception
      */
     public void setRequiredActions() throws Exception {
-        ArrayList<RequiredAction> employeeRequiredActions;
+        ArrayList<RequiredAction> employeeRequiredActions = new ArrayList<RequiredAction>();
         ArrayList<RequiredAction> administrativeActions = new ArrayList<RequiredAction>();
         ArrayList<Appraisal> myAppraisals;
         ArrayList<Appraisal> mySupervisingAppraisals;
 
         myAppraisals = (ArrayList<Appraisal>) getFromRequestMap("myAppraisals");
-        employeeRequiredActions = getAppraisalActions(myAppraisals, "employee");
+        if (myAppraisals != null) {
+            employeeRequiredActions = getAppraisalActions(myAppraisals, "employee");
+        }
         addToRequestMap("employeeActions", employeeRequiredActions);
 
         // add supervisor required actions, if user has team's active appraisals


### PR DESCRIPTION
PROC-127

When a user views their list of required actions, the list could be
null. This commits adds a check for null before trying to process
the list of appraisal for required actions.