### PR TITLE
Use https for external resources

### DIFF
--- a/docroot/WEB-INF/liferay-portlet.xml
+++ b/docroot/WEB-INF/liferay-portlet.xml
@@ -11,9 +11,9 @@
 		<header-portlet-css>/css/custom.css</header-portlet-css>
 
 		<header-portlet-css>/css/evals.css</header-portlet-css>
-		<header-portlet-css>http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css</header-portlet-css>
-        <header-portal-javascript>http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js</header-portal-javascript>
-        <header-portal-javascript>http://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js</header-portal-javascript>
+		<header-portlet-css>https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/themes/smoothness/jquery-ui.css</header-portlet-css>
+        <header-portal-javascript>https://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js</header-portal-javascript>
+        <header-portal-javascript>https://ajax.googleapis.com/ajax/libs/jqueryui/1.10.4/jquery-ui.min.js</header-portal-javascript>
         <footer-portlet-javascript>/js/jquery.autogrow-textarea.js</footer-portlet-javascript>
 	</portlet>
 	<role-mapper>


### PR DESCRIPTION
EVALS-651

I tried not specifying the protocol, but liferay doesn't support that.
If the protocol is not specified, Liferay appends the current base url