### PR TITLE
With newer version of jqery we use .prop vs attr

### DIFF
--- a/docroot/jsp/appraisals/appraisal.js
+++ b/docroot/jsp/appraisals/appraisal.js
@@ -569,7 +569,7 @@ jQuery(document).ready(function() {
    */
   function isAppraisalSigned() {
       var sigCheckbox = jQuery('#<portlet:namespace />acknowledge-release-appraisal');
-      return sigCheckbox.attr('checked');
+      return sigCheckbox.prop('checked');
   }
 
   /**


### PR DESCRIPTION
EVALS-657

The old version of Liferay came with jquery 1.2.x. Now that we
are using a newer version of jquery checking whether or not a checkbox
is checked is done using prop().