### PR TITLE
Fix padding issue of assessment text

### DIFF
--- a/docroot/css/evals.css
+++ b/docroot/css/evals.css
@@ -49,6 +49,7 @@
 
 .appraisal-criteria .pass-form-text {
     color: #555;
+    padding-left: 1em;
 }
 
 .appraisal-criteria div div {
@@ -117,6 +118,10 @@
 .appraisal-criteria .assessment-criteria label span {
   color: #C34500;
   text-decoration: underline;
+}
+
+.appraisal-criteria input[type="checkbox"] {
+  margin-left: 1em;
 }
 
 .appraisal-auto-save {


### PR DESCRIPTION
EVALS-631

The newer version of Chrome has a UI issue with the floated span
positioned outside of the parent legend.